### PR TITLE
Make Pastel OCaml < 4.05 compatible

### DIFF
--- a/src/pastel/SupportsColor.re
+++ b/src/pastel/SupportsColor.re
@@ -26,6 +26,11 @@ let geEnvOpt = s =>
   | Not_found => None
   };
 
+let bool_of_string_opt = x =>
+  try (Some(bool_of_string(x))) {
+  | Invalid_argument(_) => None
+  };
+
 let forceColor = geEnvOpt("FORCE_COLOR") >>= bool_of_string_opt;
 let (disable, minLevel) =
   switch (forceColor) {


### PR DESCRIPTION
- Shadow bool_of_string_opt implementation

I would love to have the similar CI setup as facebook/reason to ensure we run against all OCaml versions. 