### PR TITLE
fix(fp): Remove Unix and Str dependencies

### DIFF
--- a/src/dir/Dir.re
+++ b/src/dir/Dir.re
@@ -14,6 +14,9 @@
  */
 external sh_get_folder_path : (int, 'flags) => option(string) =
   "sh_get_folder_path";
+
+external sh_is_osx : unit => bool = "sh_is_osx";
+
 let shGetFolderPathCurrent = 0;
 let shGetFolderPathDefault = 1;
 
@@ -310,8 +313,7 @@ module Snapshot = (()) => {
   let platformMod =
     switch (Lazy.force(Fp.platform)) {
     | Windows(windows) => ((module Windows): (module Base))
-    | Darwin => (module Darwin)
-    | Linux => (module Linux)
+    | Posix => sh_is_osx() ? (module Darwin) : (module Linux)
     };
   include (val platformMod);
 };

--- a/src/dir/dir.c
+++ b/src/dir/dir.c
@@ -37,3 +37,16 @@ CAMLprim value sh_get_folder_path(value nFolder, value dwFlags)
   CAMLreturn(ret);
 }
 
+CAMLprim value sh_is_osx(value vUnit)
+{
+  CAMLparam0();
+  CAMLlocal1(ret);
+
+#ifdef __APPLE__
+  ret = Val_bool(1);
+#else
+  ret = Val_bool(0);
+#endif
+
+  CAMLreturn(ret);
+}

--- a/src/dir/dir.js
+++ b/src/dir/dir.js
@@ -9,3 +9,7 @@
 function sh_get_folder_path(nFolder, dwFlags) {
   throw new Error("sh_get_folder_path not implemented for JS");
 }
+
+function sh_is_osx() {
+  return false;
+}

--- a/src/fp/Fp.re
+++ b/src/fp/Fp.re
@@ -227,10 +227,7 @@ let parseFirstTokenRelative = token =>
   | DRIVE(l) => None
   };
 
-let normalizePathSeparator = {
-  let backSlashRegex = Str.regexp("\\\\");
-  pathStr => pathStr |> Str.global_replace(backSlashRegex, "/");
-};
+let normalizePathSeparator = pathStr => pathStr |> String.split_on_char('\\') |> String.concat("/");
 
 let absolutePlatform = (~fromPlatform, s) => {
   let s =

--- a/src/fp/Fp.re
+++ b/src/fp/Fp.re
@@ -40,32 +40,22 @@ let root = (Abs(None), []);
 let home = (Rel(Home, 0), []);
 let dot = (Rel(Any, 0), []);
 
-let getUname = () => {
-  let ic = Unix.open_process_in("uname");
-  let uname = String.trim(input_line(ic));
-  close_in(ic);
-  uname;
-};
-
 type windows =
-  | Cygwin
-  | Win32;
+  | Win32
+  | Cygwin;
+
 type platform =
-  | Linux
   | Windows(windows)
-  | Darwin;
+  | Posix;
 
 let platform =
   lazy (
     if (Sys.unix) {
-      switch (getUname()) {
-      | "Darwin" => Darwin
-      | _ => Linux
-      };
+      Posix
     } else if (Sys.cygwin) {
-      Windows(Cygwin);
+      Windows(Cygwin)
     } else {
-      Windows(Win32);
+      Windows(Win32)
     }
   );
 

--- a/src/fp/Fp.rei
+++ b/src/fp/Fp.rei
@@ -59,13 +59,25 @@ let root: t(absolute);
 let home: t(relative);
 let dot: t(relative);
 
+/**
+The `platform` describes how path handling should be performed - using
+Windows-style paths, or Posix-style paths.
+
+In Windows-style Win32 paths, both the back-slash and forward-slash are considered
+viable path separators. In Posix style paths, only the forward-slash is used
+as a path separator
+
+Posix-style paths are used in the following systems:
+- Linux variants
+- Mac OSX
+- Cygwin on Windows
+*/
 type windows =
-  | Cygwin
-  | Win32;
+  | Win32
+  | Cygwin;
 type platform =
-  | Linux
   | Windows(windows)
-  | Darwin;
+  | Posix;
 
 let platform: Lazy.t(platform);
 

--- a/src/fp/dune
+++ b/src/fp/dune
@@ -2,5 +2,4 @@
    (public_name fp)
    (flags :standard -w -23 -w -27 -w -32 -w -39 -w -34)
    (name Fp)
-   (libraries unix)
 )

--- a/src/fp/dune
+++ b/src/fp/dune
@@ -2,5 +2,5 @@
    (public_name fp)
    (flags :standard -w -23 -w -27 -w -32 -w -39 -w -34)
    (name Fp)
-   (libraries str unix)
+   (libraries unix)
 )


### PR DESCRIPTION
This change removes the `Unix` and `Str` dependencies from `Fp`, to make it easier to compile and use in JS.