### PR TITLE
chore(rely): Remove junit from rely

### DIFF
--- a/rely.opam
+++ b/rely.opam
@@ -16,7 +16,6 @@ depends: [
   "cli"   {"0.0.1-alpha"}
   "pastel"
   "file-context-printer"
-  "junit"
 ]
 synopsis: "A native Reason test runner that is heavily inspired by Jest"
 description: "A native Reason test runner that is heavily inspired by Jest"


### PR DESCRIPTION
It looks like junit wasn't removed from the opam file in https://github.com/reasonml/reason-native/pull/243

cc @ManasJayanth 